### PR TITLE
Fix global mouse position with x11vnc and SDL < 2.30.0

### DIFF
--- a/PCViewer/CMakeLists.txt
+++ b/PCViewer/CMakeLists.txt
@@ -66,12 +66,17 @@ endif()
 #    find_package(glslang REQUIRED)
 #endif()
 find_package(SDL2 REQUIRED)
-find_package(netCDF CONFIG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(Threads REQUIRED)
 find_package(X11 REQUIRED)
 find_package(TBB REQUIRED)
 #find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+
+find_package(netCDF CONFIG)
+if (NOT DEFINED netCDF_FOUND AND UNIX)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(netCDF netcdf)
+endif()
 
 #include_directories(${Eigen3_DIR})
 

--- a/PCViewer/imgui/imgui_impl_sdl.cpp
+++ b/PCViewer/imgui/imgui_impl_sdl.cpp
@@ -402,7 +402,14 @@ static bool ImGui_ImplSDL2_Init(SDL_Window* window, SDL_Renderer* renderer, void
     bool mouse_can_use_global_state = false;
 #if SDL_HAS_CAPTURE_AND_GLOBAL_MOUSE
     const char* sdl_backend = SDL_GetCurrentVideoDriver();
-    const char* global_mouse_whitelist[] = { "windows", "cocoa", "x11", "DIVE", "VMAN" };
+    const char* global_mouse_whitelist[] = {
+            "windows", "cocoa",
+#if SDL_VERSION_ATLEAST(2, 30, 0)
+            // https://github.com/libsdl-org/SDL/issues/8827
+            "x11",
+#endif
+            "DIVE", "VMAN"
+    };
     for (int n = 0; n < IM_ARRAYSIZE(global_mouse_whitelist); n++)
         if (strncmp(sdl_backend, global_mouse_whitelist[n], strlen(global_mouse_whitelist[n])) == 0)
             mouse_can_use_global_state = true;


### PR DESCRIPTION
This PR fixes the querying of the global mouse position by ImGui with x11vnc and SDL < 2.30.0.