### PR TITLE
Fix compilation on Fedora

### DIFF
--- a/PCViewer/CMakeLists.txt
+++ b/PCViewer/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(TBB REQUIRED)
 #find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
 find_package(netCDF CONFIG)
-if (NOT DEFINED netCDF_FOUND AND UNIX)
+if (NOT netCDF_FOUND AND UNIX)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(netCDF netcdf)
 endif()


### PR DESCRIPTION
This PR is another fix for compilation on Fedora extending commit https://github.com/wavestoweather/PCViewer/commit/bf5e832fb027c83964f642e4aa8cdc8bc05c2767. As the build previously failed due to the version of the Vulkan headers, I did not notice that there were still linking errors on Fedora. This PR fixes the problem and PCViewer now compiles and runs.